### PR TITLE
FIX# Warnings unintialized variables

### DIFF
--- a/lib/wlang/dialect.rb
+++ b/lib/wlang/dialect.rb
@@ -161,7 +161,7 @@ module WLang
 
     # Returns the current rendering scope.
     def scope
-      @scope || Scope.null
+      @scope ||= Scope.null
     end
 
     # Yields the block with a scope branched with a sub-scope `x`.

--- a/lib/wlang/tilt/wlang_template.rb
+++ b/lib/wlang/tilt/wlang_template.rb
@@ -16,7 +16,8 @@ module Tilt
       end
 
       def default_options
-        (superclass.default_options rescue {}).merge(@default_options || {})
+        @default_options ||= {}
+        (superclass.default_options rescue {}).merge(@default_options)
       end
 
     end


### PR DESCRIPTION
warning: instance variable @scope not initialized
warning: instance variable @default_options not initialized

